### PR TITLE
issue/1: Update org.apache.ant:ant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dependency-reduced-pom.xml
+target

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 !
 ! MPL 2.0 HEADER END
 !
-!     Copyright 2013 ForgeRock AS
+!     Copyright 2013-2020 ForgeRock AS
 !
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -116,7 +116,7 @@
   <dependency>
    <groupId>org.apache.ant</groupId>
    <artifactId>ant</artifactId>
-   <version>1.8.2</version>
+   <version>[1.9.15,)</version>
   </dependency>
   <dependency>
    <groupId>net.sourceforge.jexcelapi</groupId>


### PR DESCRIPTION
This patch upgrades `org.apache.ant:ant` to 1.9.15 or later.